### PR TITLE
:dart: `Fix` Fixes #165 - Crash on register auth routes

### DIFF
--- a/components/Auth/Login/LoginForm.tsx
+++ b/components/Auth/Login/LoginForm.tsx
@@ -37,7 +37,7 @@ export default function LoginForm() {
 
     const renderForm = () => {
         return (
-            <>
+            <div>
                 <Label htmlFor='email'>Email</Label>
                 <Input
                     disabled={loading}
@@ -74,7 +74,7 @@ export default function LoginForm() {
                         })}
                     />
                 </div>
-            </>
+            </div>
         );
     };
 

--- a/components/Auth/Register/RegistrationFormProvider.tsx
+++ b/components/Auth/Register/RegistrationFormProvider.tsx
@@ -25,9 +25,9 @@ export default function RegistrationFormProvider() {
     };
 
     return (
-        <>
+        <div>
             {!showForm && (
-                <>
+                <div>
                     <h3 className='text-xl font-semibold leading-none tracking-tight'>
                         Tipo de conta:
                     </h3>
@@ -93,7 +93,7 @@ export default function RegistrationFormProvider() {
                     <Button className='w-full mt-2' onClick={handleRadioSubmit}>
                         Continuar
                     </Button>
-                </>
+                </div>
             )}
             {showForm && accountType === "gymOwner" && (
                 <RegisterGymOwnerForm setShowForm={setShowForm} />
@@ -101,6 +101,6 @@ export default function RegistrationFormProvider() {
             {showForm && accountType === "member" && (
                 <RegisterMemberForm setShowForm={setShowForm} />
             )}
-        </>
+        </div>
     );
 }

--- a/components/Auth/Register/Steps/RegisterStep1.tsx
+++ b/components/Auth/Register/Steps/RegisterStep1.tsx
@@ -33,7 +33,7 @@ export default function RegisterStep1({ register, errors, loading }: StepProps) 
     const typedRegister = register as TypedRegister;
 
     return (
-        <>
+        <div>
             <div>
                 <Label htmlFor='displayName'>Nome de exibição</Label>
                 <Input
@@ -97,6 +97,6 @@ export default function RegisterStep1({ register, errors, loading }: StepProps) 
                     <p className='text-xs text-destructive mt-2'>{errors.username.message}</p>
                 )}
             </div>
-        </>
+        </div>
     );
 }

--- a/components/Auth/Register/Steps/RegisterStep2.tsx
+++ b/components/Auth/Register/Steps/RegisterStep2.tsx
@@ -33,7 +33,7 @@ export default function RegisterStep2({ register, errors, loading }: StepProps) 
     const typedRegister = register as TypedRegister;
 
     return (
-        <>
+        <div>
             <Label htmlFor='email'>Email</Label>
             <Input
                 disabled={loading}
@@ -53,6 +53,6 @@ export default function RegisterStep2({ register, errors, loading }: StepProps) 
             {errors.email && (
                 <p className='text-xs text-destructive mt-2'>{errors.email.message}</p>
             )}
-        </>
+        </div>
     );
 }

--- a/components/Auth/Register/Steps/RegisterStep3.tsx
+++ b/components/Auth/Register/Steps/RegisterStep3.tsx
@@ -45,7 +45,7 @@ export default function RegisterStep3({ register, errors, watch, loading }: Step
     const typedWatch = watch as TypedWatch;
 
     return (
-        <>
+        <div>
             <div>
                 <Label htmlFor='password'>Senha</Label>
                 <TooltipProvider delayDuration={0}>
@@ -119,6 +119,6 @@ export default function RegisterStep3({ register, errors, watch, loading }: Step
                     </p>
                 )}
             </div>
-        </>
+        </div>
     );
 }

--- a/components/Auth/Register/Steps/RegisterStep4.tsx
+++ b/components/Auth/Register/Steps/RegisterStep4.tsx
@@ -40,7 +40,7 @@ export default function RegisterStep4({ register, errors, loading }: StepProps) 
     const typedErrors = errors as TypedErrors;
 
     return (
-        <>
+        <div>
             <div>
                 <Label htmlFor='gymName'>Nome da academia</Label>
                 <Input
@@ -105,6 +105,6 @@ export default function RegisterStep4({ register, errors, loading }: StepProps) 
                     </p>
                 )}
             </div>
-        </>
+        </div>
     );
 }

--- a/components/Auth/Register/ui/SubmitButton.tsx
+++ b/components/Auth/Register/ui/SubmitButton.tsx
@@ -37,7 +37,7 @@ export default function SubmitButton({
             ) : signUpSuccess ? (
                 <Check className='absolute' />
             ) : (
-                <>{text}</>
+                <span>{text}</span>
             )}
         </button>
     );


### PR DESCRIPTION
- The app was crashing with users using Google Translations on the Auth routes
- See https://github.com/facebook/react/issues/11538#issuecomment-390386520

Solution: Removed all React fragments from the Auth routes